### PR TITLE
Better title template

### DIFF
--- a/src/org/ciscavate/cjwizard/pagetemplates/TitledPageTemplate.java
+++ b/src/org/ciscavate/cjwizard/pagetemplates/TitledPageTemplate.java
@@ -26,8 +26,9 @@ import javax.swing.border.Border;
 import org.ciscavate.cjwizard.WizardPage;
 
 /**
- * Simple PageTemplate that lists the WizardPage description at the top
- * of each page in the wizard.
+ * Simple PageTemplate that lists the WizardPage title at the top of each page
+ * in the wizard and also use the description of the page as tool tip of the
+ * title.
  * 
  * @author rogue
  */


### PR DESCRIPTION
When configured the TitledPageTemplate for the first time I was confused because it is named as **Titled** Page Template but it use the description of the page instead of the title and the title isn't used at all.

After read the JavaDoc and code I found that this is the normal behaviour, but I think is better to show the title instead of the description.

So then , I have modified the TitledPageTemplate class so it show the Title of the page instead of the description and the description is now show as a tool tip of the title.
