### PR TITLE
Remember statuses of default buttons

### DIFF
--- a/src/org/ciscavate/cjwizard/WizardContainer.java
+++ b/src/org/ciscavate/cjwizard/WizardContainer.java
@@ -17,6 +17,8 @@ package org.ciscavate.cjwizard;
 
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -66,22 +68,22 @@ public class WizardContainer extends JPanel implements WizardController {
    /**
     * The path from the start of the dialog to the current location.
     */
-   private final List<WizardPage> _path = new LinkedList<WizardPage>();
+   private final List<WizardPage> _path;
 
    /**
     * The path of already-visited pages starting from the current page.
     */
-   private final List<WizardPage> _visitedPath = new LinkedList<WizardPage>();
+   private final Deque<WizardPage> _visitedPath;
 
    /**
     * List of listeners to update on wizard events.
     */
-   private final List<WizardListener> _listeners = new LinkedList<WizardListener>();
+   private final List<WizardListener> _listeners;
 
    /**
     * The template to surround the wizard pages of this dialog.
     */
-   private PageTemplate _template = null;
+   private PageTemplate _template;
 
    /**
     * The factory that generates pages for this wizard.
@@ -92,6 +94,47 @@ public class WizardContainer extends JPanel implements WizardController {
     * The panel containing any dynamically-added buttons.
     */
    private JPanel _extraButtonPanel;
+
+   /**
+    * Save the statuses of the Next button so we can restore it when going back.
+    */
+   private Deque<Boolean> _nextStatuses;
+
+   /**
+    * Save the statuses of the Finish button so we can restore it when going back.
+    */
+   private Deque<Boolean> _finishStatuses;
+
+   /**
+    * Save the statuses of the Previous button so we can restore it when going
+    * back.
+    */
+   private Deque<Boolean> _prevStatuses;
+
+   /**
+    * Save the statuses of the Cancel button so we can restore it when going back.
+    */
+   private Deque<Boolean> _cancelStatuses;
+
+   /**
+    * Save the statuses of the Next button of visited pages.
+    */
+   private Deque<Boolean> _visitedNextStatuses;
+
+   /**
+    * Save the statuses of the Finish button of visited pages.
+    */
+   private Deque<Boolean> _visitedFinishStatuses;
+
+   /**
+    * Save the statuses of the Previous button of visited pages.
+    */
+   private Deque<Boolean> _visitedPrevStatuses;
+
+   /**
+    * Save the statuses of the Cancel button of visited pages.
+    */
+   private Deque<Boolean> _visitedCancelStatuses;
 
    private final AbstractAction _prevAction = new AbstractAction(msg.getString(I18N_PREVIOUS)) {
 
@@ -162,6 +205,20 @@ public class WizardContainer extends JPanel implements WizardController {
       _template = template;
       _settings = settings;
 
+      _path = new LinkedList<WizardPage>();
+      _visitedPath = new ArrayDeque<WizardPage>();
+      _listeners = new LinkedList<WizardListener>();
+
+      _cancelStatuses = new ArrayDeque<Boolean>();
+      _prevStatuses = new ArrayDeque<Boolean>();
+      _nextStatuses = new ArrayDeque<Boolean>();
+      _finishStatuses = new ArrayDeque<Boolean>();
+
+      _visitedCancelStatuses = new ArrayDeque<Boolean>();
+      _visitedPrevStatuses = new ArrayDeque<Boolean>();
+      _visitedNextStatuses = new ArrayDeque<Boolean>();
+      _visitedFinishStatuses = new ArrayDeque<Boolean>();
+
       initComponents();
       _template.registerController(this);
 
@@ -229,18 +286,28 @@ public class WizardContainer extends JPanel implements WizardController {
          return;
       }
 
-      _visitedPath.add(0, removing);
+      _visitedPath.push(removing);
       // update roll-back the settings:
       removing.updateSettings(getSettings());
       getSettings().rollBack();
+
+      // Save current buttons statuses.
+      _visitedCancelStatuses.push(_cancelAction.isEnabled());
+      _visitedPrevStatuses.push(_prevAction.isEnabled());
+      _visitedNextStatuses.push(_nextAction.isEnabled());
+      _visitedFinishStatuses.push(_finishAction.isEnabled());
+
+      // Restore the buttons status.
+      _cancelAction.setEnabled(_cancelStatuses.pop());
+      _prevAction.setEnabled(_prevStatuses.pop());
+      _nextAction.setEnabled(_nextStatuses.pop());
+      _finishAction.setEnabled(_finishStatuses.pop());
 
       assert 1 <= _path.size() : "Invalid path size! " + _path.size();
       setPrevEnabled(_path.size() > 1);
 
       WizardPage curPage = _path.get(_path.size() - 1);
 
-      setNextEnabled(true);
-      setFinishEnabled(false);
       // tell the page that it is about to be rendered:
       curPage.rendering(getPath(), getSettings());
       _template.setPage(curPage);
@@ -265,23 +332,55 @@ public class WizardContainer extends JPanel implements WizardController {
          getSettings().newPage(lastPage.getId());
          lastPage.updateSettings(getSettings());
 
+         // Save the current buttons status
+         _cancelStatuses.push(_cancelAction.isEnabled());
+         _prevStatuses.push(_prevAction.isEnabled());
+         _nextStatuses.push(_nextAction.isEnabled());
+         _finishStatuses.push(_finishAction.isEnabled());
+
       }
 
       // Get the next page
       WizardPage nextPage = null;
       if (_visitedPath.isEmpty()
             || _factory.isTransient(getPath(), getSettings())) {
+
          // If we can't use the cached page, create a new one.
          nextPage = _factory.createPage(getPath(), getSettings());
+
+         /*
+          * We can't know if next pages buttons statuses are ok to be restored,
+          * so we discard the visited statuses and use the defaults.
+          */
+         if (!_visitedPath.isEmpty()) {
+
+            _visitedPath.pop();
+            _visitedCancelStatuses.pop();
+            _visitedPrevStatuses.pop();
+            _visitedNextStatuses.pop();
+            _visitedFinishStatuses.pop();
+
+         }
+
+         // Estará activado por defecto si había alguna página antes.
+         setPrevEnabled(_path.size() >= 1);
+
       } else {
+
          // Else use the previously cached page.
-         nextPage = _visitedPath.remove(0);
+         nextPage = _visitedPath.pop();
+
+         // Restore the buttons status.
+         _cancelAction.setEnabled(_visitedCancelStatuses.pop());
+         _prevAction.setEnabled(_visitedPrevStatuses.pop());
+         _nextAction.setEnabled(_visitedNextStatuses.pop());
+         _finishAction.setEnabled(_visitedFinishStatuses.pop());
+
       }
 
       nextPage.registerController(this);
 
       _path.add(nextPage);
-      setPrevEnabled(_path.size() > 1);
 
       // tell the page that it is about to be rendered:
       nextPage.rendering(getPath(), getSettings());
@@ -299,24 +398,66 @@ public class WizardContainer extends JPanel implements WizardController {
          lastPage.updateSettings(getSettings());
       }
 
+      // Buttons status of the new page.
+      boolean cancelEnabled = true, previousEnabled = true, nextEnabled = true, finishEnabled = false;
+
       if (-1 == idx) {
          // new page
          if (null != lastPage) {
             // get the settings from the page that is going away:
             getSettings().newPage(lastPage.getId());
+            
+            // Save the current statuses
+            _cancelStatuses.push(_cancelAction.isEnabled());
+            _prevStatuses.push(_prevAction.isEnabled());
+            _nextStatuses.push(_nextAction.isEnabled());
+            _finishStatuses.push(_finishAction.isEnabled());
          }
 
          // add back all visited pages
          while (!_visitedPath.isEmpty()) {
-            WizardPage visited = _visitedPath.remove(0);
+
+            cancelEnabled = _visitedCancelStatuses.pop();
+            previousEnabled = _visitedPrevStatuses.pop();
+            nextEnabled = _visitedNextStatuses.pop();
+            finishEnabled = _visitedFinishStatuses.pop();
+
+            WizardPage visited = _visitedPath.pop();
             getPath().add(visited);
-            if (visited == page)
+
+            if (visited == page) {
+
+               // We have found it, use its statuses and exit from while.
+
+               _cancelAction.setEnabled(cancelEnabled);
+               setPrevEnabled(previousEnabled);
+               setNextEnabled(nextEnabled);
+               setFinishEnabled(finishEnabled);
+
                break;
+
+            } else {
+
+               _cancelStatuses.push(cancelEnabled);
+               _prevStatuses.push(previousEnabled);
+               _nextStatuses.push(nextEnabled);
+               _finishStatuses.push(finishEnabled);
+
+            }
+
          }
-         // this shouldn't happen
+
+         // If we have never seen the page, we add it to the tail.
          if (currentPage() != page) {
+            
+            assert _visitedCancelStatuses.isEmpty();
+            assert _visitedPrevStatuses.isEmpty();
+            assert _visitedNextStatuses.isEmpty();
+            assert _visitedFinishStatuses.isEmpty();
+            
             getPath().add(page);
          }
+
       } else {
          // page is in the path at idx.
 
@@ -324,13 +465,28 @@ public class WizardContainer extends JPanel implements WizardController {
          for (int i = _path.size() - 1; i > idx; i--) {
             getSettings().rollBack();
             // save visited pages
-            _visitedPath.add(0, _path.remove(i));
+            _visitedPath.push(_path.remove(i));
+            
+            // Save current buttons statuses.
+            _visitedCancelStatuses.push(_cancelStatuses.pop());
+            _visitedPrevStatuses.push(_prevStatuses.pop());
+            _visitedNextStatuses.push(_nextStatuses.pop());
+            _visitedFinishStatuses.push(_finishStatuses.pop());
+            
+            // Restore the buttons status.
+            cancelEnabled = _cancelStatuses.pop();
+            previousEnabled = _prevStatuses.pop();
+            nextEnabled = _nextStatuses.pop();
+            finishEnabled = _finishStatuses.pop();
          }
+
+         _cancelAction.setEnabled(cancelEnabled);
+         setPrevEnabled(previousEnabled);
+         setNextEnabled(nextEnabled);
+         setFinishEnabled(finishEnabled);
+
       }
 
-      setPrevEnabled(_path.size() > 1);
-
-      setNextEnabled(true);
       page.rendering(_path, getSettings());
       _template.setPage(page);
       firePageChanged(page, _path);


### PR DESCRIPTION
When going backwards the finish button must be let as its default state (disabled) like the next button.

If a wizard need to let it enabled (because all settings needed have been filled previously) it will need to re-enable it in rendering.

This fix issue #1.

However, a better approach is perhaps to save the status of the button and restore it.
