### PR TITLE
Italian and German i8n, fixed javadoc compilation error

### DIFF
--- a/src/main/java/com/github/cjwizard/APageFactory.java
+++ b/src/main/java/com/github/cjwizard/APageFactory.java
@@ -25,7 +25,7 @@ import java.util.List;
  * implementations so you don't get in problems if new functionality is added
  * to the {@link PageFactory} interface.
  *
- * @author Javier Alfonso <phoneixsegovia@gmail.com>
+ * @author <a href="mailto:phoneixsegovia@gmail.com">Javier Alfonso</a>
  * @version 20140929
  *
  */

--- a/src/main/java/com/github/cjwizard/StackWizardSettings.java
+++ b/src/main/java/com/github/cjwizard/StackWizardSettings.java
@@ -340,7 +340,7 @@ public class StackWizardSettings implements WizardSettings {
     * 
     * @return <code>true</code> If active keys are the same in both settings and
     *         its values are also equals.
-    * @author Javier Alfonso <PhoneixSegovia@gmail.com>
+    * @author <a href="mailto:PhoneixSegovia@gmail.com">Javier Alfonso</a>
     */
    public boolean settingsEquals(WizardSettings ws) {
 

--- a/src/main/java/com/github/cjwizard/WizardController.java
+++ b/src/main/java/com/github/cjwizard/WizardController.java
@@ -66,13 +66,13 @@ public interface WizardController {
    
    /**
     * Forcibly visit the next page.  This is equivalent to the user clicking on
-    * "Next >", but this <b>can</b> be done when the button is disabled.
+    * "Next &gt;", but this <b>can</b> be done when the button is disabled.
     */
    public void next();
    
    /**
     * Forcibly visit the previous page.  This is equivalent to the user clicking on
-    * "< Prev", but this <b>can</b> be done when the button is disabled.
+    * "&lt; Prev", but this <b>can</b> be done when the button is disabled.
     */
    public void prev();
    

--- a/src/main/java/com/github/cjwizard/i18n/cjwizard_de.properties
+++ b/src/main/java/com/github/cjwizard/i18n/cjwizard_de.properties
@@ -1,0 +1,4 @@
+PREVIOUS=Zuruck
+NEXT=Nachste
+FINISH=Fertig
+CANCEL=Cancel

--- a/src/main/java/com/github/cjwizard/i18n/cjwizard_it.properties
+++ b/src/main/java/com/github/cjwizard/i18n/cjwizard_it.properties
@@ -1,0 +1,4 @@
+PREVIOUS=Indietro
+NEXT=Avanti
+FINISH=Finisci
+CANCEL=Annulla


### PR DESCRIPTION
* Added i8n for Italian and German language 
* fixed compilation error "malformed HTML" in javadoc comments