### PR TITLE
Added the option to forget the path when a conditional wizard is crea…

### DIFF
--- a/src/main/java/com/github/cjwizard/WizardContainer.java
+++ b/src/main/java/com/github/cjwizard/WizardContainer.java
@@ -74,6 +74,13 @@ public class WizardContainer extends JPanel implements WizardController {
     * The path from the start of the dialog to the current location.
     */
    private final List<WizardPage> _path;
+   
+   /**
+     * In a wizard with a conditional path if after having traversed once the pages
+     * I hit back and re-traverse the pages should I store the previously selected
+     * path and use it or forget it. By default this is false.
+     */
+    private boolean forgetTraversedPath = false;
 
    /**
     * The path of already-visited pages starting from the current page.
@@ -350,7 +357,7 @@ public class WizardContainer extends JPanel implements WizardController {
       // Get the next page
       WizardPage nextPage = null;
       if (_visitedPath.isEmpty()
-            || _factory.isTransient(getPath(), getSettings())) {
+            || _factory.isTransient(getPath(), getSettings()) || forgetTraversedPath) {
 
          // If we can't use the cached page, create a new one.
          nextPage = _factory.createPage(getPath(), getSettings());
@@ -650,5 +657,13 @@ public class WizardContainer extends JPanel implements WizardController {
    public void setCancelEnabled(boolean enabled) {
       _cancelAction.setEnabled(enabled);
    }
+
+    /**
+     * @param forgetTraversedPath the forgetTraversedPath to set
+     */
+    public void setForgetTraversedPath(boolean forgetTraversedPath)
+    {
+        this.forgetTraversedPath = forgetTraversedPath;
+    }
 
 }

--- a/src/main/java/com/github/cjwizard/WizardTest.java
+++ b/src/main/java/com/github/cjwizard/WizardTest.java
@@ -60,6 +60,12 @@ public class WizardTest extends JDialog {
                              new TitledPageTemplate(),
                              new StackWizardSettings());
       
+      //do you want to store previously visited path and repeat it if you hit back
+      //and then go forward a second time?
+      //this options makes sense if you have a conditional path where depending on choice of a page
+      // you can visit one of two other pages.
+      wc.setForgetTraversedPath(true);
+      
       // add a wizard listener to update the dialog titles and notify the
       // surrounding application of the state of the wizard:
       wc.addWizardListener(new WizardListener(){


### PR DESCRIPTION
…ted.

In a conditional wizard if you make a choice and visit a page based on that choice if you then
hit back you can change your choice but if you don't forget the previous path the second
time your choice will not be taken into account.
In the case above you can set the wizardContainer.setForgetTraversedPath(true);