### PR TITLE
Update travis.yml to include all oracle and openjdk versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: java
 
 jdk:
-  - oraclejdk8
   - openjdk7
   - openjdk8
+  - oraclejdk8
+  - openjdk9
   - oraclejdk9
-  - oraclejdk11
   - openjdk10
+  - oraclejdk10
   - openjdk11
+  - oraclejdk11
   
 script:
   - mvn clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ jdk:
   - openjdk9
   - oraclejdk9
   - openjdk10
-  - oraclejdk10
   - openjdk11
   - oraclejdk11
   


### PR DESCRIPTION
Travis.yml now includes Oracle AND OpenJDK entries for Java 8, 9, 10 and 11; we were missing a couple.

OpenJDK 7 is also included.