### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ jdk:
   - oraclejdk11
   
 script:
-  - mvn -T 1C clean install
-  - mvn -T 1C site
-  - mvn -T 1C site:stage
+  - mvn clean install
+  - mvn site
+  - mvn site:stage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ jdk:
   - oraclejdk11
   
 script:
-  - mvn clean install
-  - mvn site
-  - mvn site:stage
+  - mvn -T 1C clean install
+  - mvn -T 1C site
+  - mvn -T 1C site:stage

--- a/cjwizard-demo/pom.xml
+++ b/cjwizard-demo/pom.xml
@@ -79,17 +79,8 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-        </dependency>
-
-        <!-- Test Scope -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
+         
+        
 
         
         <dependency>

--- a/cjwizard/pom.xml
+++ b/cjwizard/pom.xml
@@ -65,11 +65,7 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
+    
 
   </dependencies>
 


### PR DESCRIPTION

[Parallel builds in Maven 3](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) Maven 3.x has the capability to perform parallel builds.

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
cjwizard-parent
cjwizard
{groupId='org.slf4j', artifactId='slf4j-simple'}
cjwizard-demo
{groupId='org.slf4j', artifactId='slf4j-simple'}
{groupId='junit', artifactId='junit'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
